### PR TITLE
Add temporary landing page for call for volunteers 

### DIFF
--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -30,7 +30,7 @@ The program committee is responsible for making sure that the schedule of tutori
 
 ### Pre-conference responsibilities
 
-- Start the call for proposals process (ideally opening in February or March 2023)
+- Start the call for proposals process (opened in March 2024, closes April 24)
 - Coordinate with the Opportunity Grants team to schedule the opening and closing of the CFP
 - Publish blog posts announcing the CFP, speaker mentors, and speaker resources
 - Recruit keynote speakers (the DEFNA board will offer suggestions, but if you have a message you'd like the keynotes to send, you have lots of latitude here, but keep in mind conference diversity goals)

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -16,7 +16,7 @@ Ideally, all committees will have a chair and co-chair to allow for one or the o
 
 ## Conference Leadership
 
-The conference chair and co-chair lead the conference, including coordinating between teams and making executive decisions (including approaching the DEFNA board when applicable). Expect to be in meetings with the venue and online conference provider, weekly organizer check-ins, monthly reports to the DEFNA board, and lots of questions on Slack. You'll also lead the volunteer kickoff meetings in early 2023 (ideally mid-to-late January) and recruit organizers as you see fit. You'll need to recommend an online conference provider to the DEFNA board (might be part of a sponsorship deal).
+The conference chair and co-chair lead the conference, including coordinating between teams and making executive decisions (including approaching the DEFNA board when applicable). Expect to be in meetings with the venue and online conference provider, weekly organizer check-ins, monthly reports to the DEFNA board, and lots of questions on Slack. You'll also lead the volunteer kickoff meetings in early 2024 (ideally mid-to-late January) and recruit organizers as you see fit. You'll need to recommend an online conference provider to the DEFNA board (might be part of a sponsorship deal).
 
 At the conference, you'll be making speeches at the start of each day and the end-of-conference wrap-up in addition to coordinating setup, teardown, and everything in between.
 

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -6,7 +6,7 @@ layout: post
 title: "Call for Volunteers: DjangoCon US 2024"
 ---
 
-As our program chair, Drew Winstel, mentioned in his opening remarks today, we would love to have more volunteers for DjangoCon US 2023. Expect to hear details on dates and venues within the next month or so.
+Organizing DjangoCon US 2024 has begun! We need organizers to help make DjangoCon US 2024 the best it can be.
 
 We have some [documentation about the various roles](https://djangocon.github.io/djangocon-us-docs/), but here's a quick overview of the teams at DjangoCon US.
 

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -36,7 +36,7 @@ The program committee is responsible for making sure that the schedule of tutori
 - Recruit keynote speakers (the DEFNA board will offer suggestions, but if you have a message you'd like the keynotes to send, you have lots of latitude here, but keep in mind conference diversity goals)
 - Recruit speaker mentors (start with the 2019, 2021, and 2022 reviewers and bring in more as you like)
 - Review proposals as they come in for anonymization (ideally, recruit one member of the program committee who will not be reviewing talks to do the anonymization before opening talks for review)
-- Recruit talk reviewers (the DEFNA board will send you the 2022 reviewers, but more reviewers are encouraged, especially from diverse backgrounds). There will likely be over 100 submissions, so having more reviewers lessens the load for individual talks
+- Recruit talk reviewers (the DEFNA board will send you the 2023 reviewers, but more reviewers are encouraged, especially from diverse backgrounds). There will likely be over 100 submissions, so having more reviewers lessens the load for individual talks
 - Decide on any tweaks to the format (Spanish-language talks? Keep the Deep Dive Day? This is your chance to put your mark on the program)
 - Review talks
 - Once reviews are completed, de-anonymize talks and filter for duplicate speakers, multiple speakers from the same organization, diversity goals, overlapping topics, and more

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -254,7 +254,7 @@ Size: 2-4
 
 The communications committee is responsible for getting the word out about DCUS.
 
-Have you heard the expression "never tweet" (usually said on Twitter)? This is the opposite of that. Always tweet.
+This team manages the various DCUS social network feeds, including Twitter, Mastodon, Bluesky, Instagram, LinkedIn, and more. This team also edits and posts blogs on the DCUS main page and coordinates bulk emails to ticketholders to remind them about the conference as it approaches.
 
 ### Pre-conference responsibilities
 

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -1,0 +1,310 @@
+---
+author: Abigail Afi Gbadago
+category: General
+date: 2024-04-05 12:00:00-07:00
+layout: post
+title: "Call for Volunteers: DjangoCon US 2024"
+---
+
+As our program chair, Drew Winstel, mentioned in his opening remarks today, we would love to have more volunteers for DjangoCon US 2023. Expect to hear details on dates and venues within the next month or so.
+
+We have some [documentation about the various roles](https://djangocon.github.io/djangocon-us-docs/), but here's a quick overview of the teams at DjangoCon US.
+
+The DEFNA board will not leave you stranded; we have a lot of documentation to help you on your way, including rough checklists of tasks needed for each team.
+
+Ideally, all committees will have a chair and co-chair to allow for one or the other to take vacations, handle day job duties, and so forth. This list is by no means comprehensive, but it should hopefully give you an idea of what each committee is responsible for.
+
+## Conference Leadership
+
+The conference chair and co-chair lead the conference, including coordinating between teams and making executive decisions (including approaching the DEFNA board when applicable). Expect to be in meetings with the venue and online conference provider, weekly organizer check-ins, monthly reports to the DEFNA board, and lots of questions on Slack. You'll also lead the volunteer kickoff meetings in early 2023 (ideally mid-to-late January) and recruit organizers as you see fit. You'll need to recommend an online conference provider to the DEFNA board (might be part of a sponsorship deal).
+
+At the conference, you'll be making speeches at the start of each day and the end-of-conference wrap-up in addition to coordinating setup, teardown, and everything in between.
+
+These two roles have the highest time commitment and the most visibility. If you want to help people get things done and get up on stage, these are the roles for you.
+
+## Program Committee
+
+Size: 2-4
+
+The program committee is responsible for making sure that the schedule of tutorials and talks is the best it can be.
+
+### Pre-conference responsibilities
+
+- Start the call for proposals process (ideally opening in February or March 2023)
+- Coordinate with the Opportunity Grants team to schedule the opening and closing of the CFP
+- Publish blog posts announcing the CFP, speaker mentors, and speaker resources
+- Recruit keynote speakers (the DEFNA board will offer suggestions, but if you have a message you'd like the keynotes to send, you have lots of latitude here, but keep in mind conference diversity goals)
+- Recruit speaker mentors (start with the 2019, 2021, and 2022 reviewers and bring in more as you like)
+- Review proposals as they come in for anonymization (ideally, recruit one member of the program committee who will not be reviewing talks to do the anonymization before opening talks for review)
+- Recruit talk reviewers (the DEFNA board will send you the 2022 reviewers, but more reviewers are encouraged, especially from diverse backgrounds). There will likely be over 100 submissions, so having more reviewers lessens the load for individual talks
+- Decide on any tweaks to the format (Spanish-language talks? Keep the Deep Dive Day? This is your chance to put your mark on the program)
+- Review talks
+- Once reviews are completed, de-anonymize talks and filter for duplicate speakers, multiple speakers from the same organization, diversity goals, overlapping topics, and more
+- Select the best talks (where "best" is extremely subjective; we have documentation on things we look for in good proposals); you're not strictly bound to pick the highest scoring talks, so you have some leeway
+- Coordinate with the Opportunity Grants team to send them a list of accepted speakers so they can prioritize them for awards
+- Coordinate with the OG team to notify speakers in waves (ideally completed by July 1)
+- Build a schedule (ideally by July 15)
+- Publish blog posts announcing speakers and keynotes (ideally by August 15)
+- Update schedules based on speakers' needs
+- Coordinate with the DEFNA board to approve reimbursement requests
+- Generate cue sheets for session chairs and speaker mentors
+- Review online talks for Code of Conduct compliance
+- Recruit backup speakers in case of speakers having to back out (visa issues, illness, etc.)
+- Work with the social events team to arrange a speaker appreciation dinner
+- Generate spreadsheets in multiple formats to make other teams' lives easier
+
+### At-conference responsibilities
+
+- Work with registration desk to make sure that all speakers show up
+- Work with session managers (other organizers) to ensure distribution of cue sheets and speaker gifts
+- Check with tutorial speakers to make sure they have everything they need
+
+## Opportunity Grants Committee
+
+Size: 2 (plus reviewers)
+
+The OG committee is responsible for obtaining grants from the DSF and PSF and awarding grants to people who will best use them, prioritizing speakers, first time attendees, and people from underrepresented and/or historically disadvantaged groups.
+
+### Pre-conference responsibilities
+
+- Start call for grants process (concurrent with CFP)
+- Publish blog posts announcing the grant process
+- Request grants from the Django Software Foundation and Python Software Foundation (the DEFNA board will help you fill out the forms)
+- Recruit grant reviewers (other organizers and DEFNA members are happy to help)
+- Review submissions
+- Coordinate with the program team about grants to speakers
+- Notify grant recipients in waves (concurrent with program notifications)
+- Communicate with recipients on how to get reimbursed (we'll have templates)
+- Give DEFNA a list of recipients and amounts
+- Approve reimbursements as requests come in
+- Coordinate with the visa (community) team as needed to approve invitation letter requests
+- Write a transparency report giving a high-level overview of how the grants were awarded
+
+### At-conference responsibilities
+
+- Answer questions from grant recipients and the DEFNA board
+
+## Community Team
+
+Size: 2-4
+
+### Pre-conference responsibilities
+
+- Schedule orientation
+- Arrange childcare and lactation room
+- Coordinate visa applications
+- Improve accessibility of the venue and conference as a whole
+
+### At-conference responsibilities
+
+- Post-sign-ups for the lactation room and distribute keys as needed
+- Collect receipts for childcare reimbursement
+
+## Sponsorship Committee
+
+Size: 2-4
+
+The sponsorship committee recruits sponsors which helps offset the cost of running DCUS.
+
+### Pre-conference responsibilities
+
+- Create and announce sponsorship prospectus (we have templates, and DEFNA will help with specifics)
+- Recruit sponsors
+- Coordinate contract signing with DEFNA
+- Consider awarding community sponsorships (non-financial) to other non-profit Python conferences and related communities (local Python meetups near the conference will love the exposure)
+- Coordinate shipping of sponsor swag for the swag bag
+- Lay out sponsor tables (on a venue map)
+- Work with sponsor chair/co-chair to handle sponsor shout-outs if needed
+- Order banners to go behind the speakers on stage
+
+### At-conference responsibilities
+
+- Direct sponsors to their booths/tables and swag
+- Ensure that booths are reserved for sponsors who have reserved a booth, and are not open for others
+- Field complaints/questions from sponsors
+
+## Code of Conduct Committee
+
+Size: 4-6
+
+The CoC committee suggests improvements to the CoC and investigates reports. This is the heart of the conference because, without the CoC, we wouldn't have the welcoming environment that we have at DCUS.
+
+### Pre-conference responsibilities
+
+- Suggest modifications/improvements to the CoC
+- Assist program committee with pre-conference review of recorded online talks
+
+### At-conference responsibilities
+
+- Field reports and investigate them, including recommending actions to the DEFNA board
+- Follow up on reports, including conversations with both reporters and those who have been reported, and facilitate the appropriate response
+- Write a CoC transparency report to recap reports (heavily anonymized) and actions taken
+
+## Social Events Committee
+
+Size: 2-3
+
+The social events committee is responsible for scheduling the "after-hours" events at DCUS to give people chances to socialize and unwind after a long day of talks.
+
+### Pre-conference responsibilities
+
+- Find a venue for the speaker appreciation dinner and coordinate contract signing with DEFNA
+- Plan opening reception (if sponsored, this will become a bigger event compared to previous years)
+- Plan any other fun events like board game night
+
+### At-conference responsibilities
+
+- Work with the venue on any work needed for social events
+
+## Venue Committee
+
+Size: 1-2
+
+The venue committee is responsible for coordinating plans between the other organizing teams and the venue(s).
+
+### Pre-conference responsibilities
+
+- Work with the event venue to select and lay out talk, tutorial, and sprint rooms
+- Lay out the extra rooms needed for the conference (lactation room, quiet room, organizers room, speaker green room, lunch/break areas)
+- Work with event venue and DEFNA to select catering menus (and providers if we're not contractually obligated to use one)
+- Work with the hotel to coordinate room blocks
+- Work with the venue to plan logistics (sponsor gear shipping, signage, etc.)
+- Allocate reward rooms in coordination with the DEFNA board
+- Order supplies for restroom stocking
+
+### At-conference responsibilities
+
+- Review room guest list against ticket list to claim reward nights
+- Handle any last-minute requests from vendors/sponsors/organizers/etc.
+- Notify venue staff of any needs (bathroom cleanliness, meals to accommodate special diets, etc.)
+
+## Online Committee
+
+Size: 2-3
+
+### During-conference responsibilities
+- Set up online tutorials
+- Increase online engagement during the conference
+- Investigate online lightning talks
+
+## Audio/Video (A/V) Committee
+
+Size: 2-3
+
+The A/V committee is responsible for making everything look good. They handle coordination between the on-site crew, the online streaming platform, and the post-conference processing teams and upload the results to YouTube after the conference.
+
+### Pre-conference responsibilities
+
+- Select on-site video production crew
+- Select post-conference processing crew
+- Coordinate both of the above teams with the online platform
+- Work with the venue team to ensure high-speed wired internet access to the on-site video crew
+- Transfer pre-recorded talks to the post-conference processing crew and then the online conference provider
+- Procure a wide variety of dongles for presenters to hook their laptops up to the projectors
+- Procure projectors and screens if the venue doesn't already have them, including one for the green room so speakers can test their setup
+
+### At-conference responsibilities
+
+- Help on-site crew set up equipment and ensure streaming works
+- Get dongles to the right rooms as needed
+- Help keynote speakers get presentation mode working if needed
+- Answer lots and lots of questions
+
+## Swag Committee
+
+Size: 1-2
+
+The swag committee is responsible for everything speakers and attendees take home from the conference (aside from knowledge!).
+
+### Pre-conference responsibilities
+
+- Design and order attendee t-shirts (with sponsor logos)
+- Design and order swag bags (with sponsor logos)
+- Design and order speaker gifts
+- Design and order DCUS-branded swag (stickers/magnets/etc.)
+- Order masks and COVID tests (if needed)
+- Order lanyards, badges, and badge flags
+
+### At-conference responsibilities
+
+- Recruit volunteers to stuff swag bags on Sunday afternoon
+- Get T-shirts and swag bags to the registration desk
+- Get speaker gifts to the program team for distribution
+
+## Volunteer Committee
+
+Size: 2
+
+The volunteer committee is responsible for cultivating new volunteers, who can become organizers in future years.
+
+### Pre-conference responsibilities
+
+- Determine what roles need on-site volunteer support (session chairs, session managers, registration desk, etc.)
+- Set up sign-up for on-site volunteers and online volunteers (moderators/cheerleaders)
+- Draft announcements for calls for volunteers
+
+### At-conference responsibilities
+
+- Tell volunteers where to go
+- Give volunteers tools to succeed
+
+## Communications Committee
+
+Size: 2-4
+
+The communications committee is responsible for getting the word out about DCUS.
+
+Have you heard the expression "never tweet" (usually said on Twitter)? This is the opposite of that. Always tweet.
+
+### Pre-conference responsibilities
+
+- Publish announcements and reminders on social media, the conference blog, and more (Django News, Python Community News, etc.)
+- Send a copy to the Django Software Foundation to get major news events on the Django blog
+- Review, edit, and suggest copy for the other teams' announcements
+- Tweet. Lots of tweeting.
+- Select an "official emoji" for the conference (typically suggested by the design package for the year's website)
+- Boost and retweet speakers and organizers talking about the conference
+- Schedule tweets announcing talks and events
+
+### At-conference responsibilities
+
+- Pay attention to the `#djangocon` topic on social media and mentions to `@djangocon` on Twitter
+- Boost speakers and organizers
+- Answer questions as they come up
+- Run the `#help-desk` channel on the conference attendee slack
+
+## Website Committee
+
+Size: 2-3
+
+The website committee is responsible for updating the website as the conference transitions through phases (CFP coming soon, CFP open, CFP closed, schedule released, hotel block closed, conference over, etc.), reviewing pull requests, and adding content (e.g. new sponsors). This requires the most coding of any team aside from maybe the program team.
+
+### Pre-conference responsibilities
+
+- Update static pages for CFP status
+- Update static pages for venue information
+- Review pull requests from other teams
+- Add sponsors as directed by the sponsorship team
+
+## Automation Team
+
+This team is more free-flowing and writes scripts to make teams' lives easier. Responsibilities vary based on the year, and if you have ideas for special projects for the future, have at it!
+
+## Sprints Team
+
+Size: 2-4
+
+### Pre-conference responsibilities
+
+- Write blog posts announcing sprints
+- Invite people to launch special sessions (e.g. Carlton's ["Getting Started Contributing to Django"](https://2022.djangocon.us/sprints/getting-started-contributing-to-django/))
+- Ensure we have signage and power equipment
+
+### At-conference responsibilities
+
+- Coordinate help desk
+- Direct people to lunches and breaks
+
+## Wrap-up
+
+To sign up for any of the teams (or just say "Put me to work"), send an email to hello@djangocon.us and we'll put you on the list for the 2023 kickoff meeting. We would love to have you! You do not have to have previous organizing experience (although we might prefer it for some of the leadership roles).

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -307,4 +307,4 @@ Size: 2-4
 
 ## Wrap-up
 
-To sign up for any of the teams (or just say "Put me to work"), send an email to hello@djangocon.us and we'll put you on the list for the 2023 kickoff meeting. We would love to have you! You do not have to have previous organizing experience (although we might prefer it for some of the leadership roles).
+To sign up for any of the teams (or just say "Put me to work"), send an email to hello@djangocon.us and we'll add you to our organizer Slack instance and invite you to our fortnightly organizer catch-up meetings. We would love to have you! You do not have to have previous organizing experience (although we might prefer it for some of the leadership roles).

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -183,7 +183,6 @@ The venue committee is responsible for coordinating plans between the other orga
 Size: 2-3
 
 ### During-conference responsibilities
-- Set up online tutorials
 - Increase online engagement during the conference
 - Investigate online lightning talks
 

--- a/_posts/2024-04-05-call-for-2024-volunteers.md
+++ b/_posts/2024-04-05-call-for-2024-volunteers.md
@@ -268,7 +268,7 @@ This team manages the various DCUS social network feeds, including Twitter, Mast
 
 ### At-conference responsibilities
 
-- Pay attention to the `#djangocon` topic on social media and mentions to `@djangocon` on Twitter
+- Pay attention to the `#djangocon` topic on social media and mentions to `@djangocon` on various social networks
 - Boost speakers and organizers
 - Answer questions as they come up
 - Run the `#help-desk` channel on the conference attendee slack


### PR DESCRIPTION

## Description

Transferred call for volunteers post from DjangoCon US 2022 page and added reference for Online Commite with data from the Kickoff Meeting Slides.

## Related Issue
Ref: 
[Fix call for volunteers on temporary landing page #33](https://github.com/djangocon/2024.djangocon.us/issues/33)
