### PR TITLE
Mark the OG and CFP as being closed

### DIFF
--- a/_pages/homepage-coming-soon.html
+++ b/_pages/homepage-coming-soon.html
@@ -376,7 +376,9 @@ title: DjangoCon US 2024 will be at the Durham Convention Center in Durham, Nort
       </p>
       <h2 class="conf-description">Book your <a href="https://www.marriott.com/events/start.mi?id=1707512209729&key=GRP">hotel room</a> at the <a href="https://www.marriott.com/en-us/hotels/rducv-durham-marriott-city-center/overview/">Marriott Durham City Center</a></h2>
           <p>The hotel connects directly to the convention center.</p>
+      {% comment %}
       <h2 class="conf-description">Our <a href="/speaking/">Call for Proposals</a> and <a href="/opportunity-grants/">Opportunity Grant applications</a> are now open!</h2>
+      {% encomment %}
     </header>
     <main class="siteMain">
       <div class="featuresBlock">

--- a/_pages/homepage-coming-soon.html
+++ b/_pages/homepage-coming-soon.html
@@ -378,7 +378,7 @@ title: DjangoCon US 2024 will be at the Durham Convention Center in Durham, Nort
           <p>The hotel connects directly to the convention center.</p>
       {% comment %}
       <h2 class="conf-description">Our <a href="/speaking/">Call for Proposals</a> and <a href="/opportunity-grants/">Opportunity Grant applications</a> are now open!</h2>
-      {% encomment %}
+      {% endcomment %}
     </header>
     <main class="siteMain">
       <div class="featuresBlock">

--- a/_pages/opportunity-grants.md
+++ b/_pages/opportunity-grants.md
@@ -8,17 +8,18 @@ permalink: /opportunity-grants/
 title: Opportunity Grants
 ---
 
+{% comment %}
 **UPDATE**: The application window has been extended to Monday, April 29th at Noon EDT!
 
 Our <a href="{{site.opportunity_grant_application}}">opportunity grant application</a> is open until April 29, 2024 at [12 PM EDT](https://time.is/1200PM_29_Apr_2024_in_New_York?DjangoCon_US_2024_CFP_closes).
+{% endcomment %}
 
 {% comment %}
 Our opportunity grant application window is now closed. All decision notifications have been sent.
 {% endcomment %}
 
-{% comment %}
 Our opportunity grant application window is now closed. All decision notifications will be sent by June 14th, 2024.
-{% endcomment %}
+
 If you have any questions, feel free to reach out to the opportunity grants team at [{{ site.opportunity_grants_email }}](mailto:{{ site.opportunity_grants_email }}).
 
 <br>
@@ -42,7 +43,7 @@ We feel the wording "opportunity grants" makes a positive shift towards being a 
 
 ### When will I find out whether I've received an opportunity grant?
 
-You will be notified by June 14, 2024.
+You will be notified by July 8, 2024.
 
 {% comment %}
 You should have received your notification. If you haven't, please email the opportunity grant team at [{{ site.opportunity_grants_email }}](mailto:{{ site.opportunity_grants_email }}).

--- a/_pages/opportunity-grants.md
+++ b/_pages/opportunity-grants.md
@@ -18,7 +18,7 @@ Our <a href="{{site.opportunity_grant_application}}">opportunity grant applicati
 Our opportunity grant application window is now closed. All decision notifications have been sent.
 {% endcomment %}
 
-Our opportunity grant application window is now closed. All decision notifications will be sent by June 14th, 2024.
+Our opportunity grant application window is now closed. All decision notifications will be sent by July 8th, 2024.
 
 If you have any questions, feel free to reach out to the opportunity grants team at [{{ site.opportunity_grants_email }}](mailto:{{ site.opportunity_grants_email }}).
 

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -11,15 +11,16 @@ redirect_from:
 {% comment %}
 Our Call for Proposals (CFP) will open soon!
 {% endcomment %}
-{% comment %}
+
 Our Call for Proposals is now closed.
-Decision notifications will be sent by June 28th, 2023.
-{% endcomment %}
+Decision notifications will be sent by July 8th, 2024.
+
 
 {% comment %}
 Our Call for Proposals is now closed and all decision notifications have been sent.
 {% endcomment %}
 
+{% comment %}
 **UPDATE**: The CFP has been extended to Monday, April 29th at Noon EDT!
 
 Our <a href="{{ site.cfp_application }}">Call for Proposals (CFP)</a> is now open!
@@ -28,6 +29,7 @@ Submit your talk or tutorial proposal by April 29, 2024 at [12 PM EDT](https://t
 Need help with your proposal? We've got mentors and helpful tips on our [Speaker Resources](/speaking/speaker-resources/) page!
 
 <a href="{{site.cfp_application}}" class="button">Submit a Proposal</a>
+{% endcomment %}
 
 ## Why Speak at DjangoCon US?
 


### PR DESCRIPTION

## Description

Removes the links to submit to the CFP/OGs from the home page, speaking page, and OG page
